### PR TITLE
DEV: Fixes frontend tests

### DIFF
--- a/test/javascripts/acceptance/discourse-video-disabled-test.js.es6
+++ b/test/javascripts/acceptance/discourse-video-disabled-test.js.es6
@@ -1,15 +1,20 @@
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
+import { clearToolbarCallbacks } from "discourse/components/d-editor";
 
-acceptance("Discourse video disabled", {
-  loggedIn: true,
-  settings: {
-    discourse_video_enabled: false
-  },
-});
+acceptance("Discourse video disabled", function (needs) {
+  needs.user();
+  needs.settings({
+    discourse_video_enabled: false,
+  });
+  needs.hooks.beforeEach(() => clearToolbarCallbacks());
 
-test("Doesn't shows upload video icon in composer", async (assert) => {
-  await visit("/");
-  await click("#create-topic");
+  test("Doesn't shows upload video icon in composer", async (assert) => {
+    await visit("/");
+    await click("#create-topic");
 
-  assert.ok(!exists(".discourse-video-upload"), "the upload video button is not available");
+    assert.ok(
+      !exists(".discourse-video-upload"),
+      "the upload video button is not available"
+    );
+  });
 });

--- a/test/javascripts/acceptance/discourse-video-enabled-test.js.es6
+++ b/test/javascripts/acceptance/discourse-video-enabled-test.js.es6
@@ -1,18 +1,26 @@
-import { acceptance, updateCurrentUser } from "discourse/tests/helpers/qunit-helpers";
+import {
+  acceptance,
+  updateCurrentUser,
+} from "discourse/tests/helpers/qunit-helpers";
+import { clearToolbarCallbacks } from "discourse/components/d-editor";
 
-acceptance("Discourse video enabled", {
-  loggedIn: true,
-  settings: {
+acceptance("Discourse video enabled", function (needs) {
+  needs.user();
+  needs.settings({
     discourse_video_enabled: true,
     discourse_video_file_extensions: "mp4|mov|wmv|avi|mkv|mpg|mpeg|ogg",
-    discourse_video_min_trust_level: 1
-  },
-});
+    discourse_video_min_trust_level: 1,
+  });
+  needs.hooks.beforeEach(() => clearToolbarCallbacks());
 
-test("Shows upload video button in composer", async (assert) => {
-  updateCurrentUser({ trust_level: 1 });
-  await visit("/");
-  await click("#create-topic");
+  test("Shows upload video button in composer", async (assert) => {
+    updateCurrentUser({ can_upload_video: true });
+    await visit("/");
+    await click("#create-topic");
 
-  assert.ok(exists(".discourse-video-upload"), "the upload video button is available");
+    assert.ok(
+      exists(".discourse-video-upload"),
+      "the upload video button is available"
+    );
+  });
 });

--- a/test/javascripts/acceptance/discourse-video-upload-button-test.js.es6
+++ b/test/javascripts/acceptance/discourse-video-upload-button-test.js.es6
@@ -1,37 +1,42 @@
-import { acceptance, updateCurrentUser } from "discourse/tests/helpers/qunit-helpers";
+import {
+  acceptance,
+  updateCurrentUser,
+} from "discourse/tests/helpers/qunit-helpers";
+import { clearToolbarCallbacks } from "discourse/components/d-editor";
 
-acceptance("Discourse video upload button visibility in composer", {
-  loggedIn: true,
-  settings: {
-    discourse_video_enabled: true,
-    discourse_video_file_extensions: "mp4|mov|wmv|avi|mkv|mpg|mpeg|ogg",
-    discourse_video_min_trust_level: 1
-  },
-});
+acceptance(
+  "Discourse video upload button visibility in composer",
+  function (needs) {
+    needs.user();
+    needs.settings({
+      discourse_video_enabled: true,
+      discourse_video_file_extensions: "mp4|mov|wmv|avi|mkv|mpg|mpeg|ogg",
+      discourse_video_min_trust_level: 1,
+    });
+    needs.hooks.beforeEach(() => clearToolbarCallbacks());
 
-test("it shows upload button when user has specified trust level", async (assert) => {
-  updateCurrentUser({ trust_level: 1 });
+    test("it shows upload button when can_upload_video is true", async (assert) => {
+      updateCurrentUser({ can_upload_video: true });
 
-  await visit("/");
-  await click("#create-topic");
+      await visit("/");
+      await click("#create-topic");
 
-  assert.ok(exists(".discourse-video-upload"), "the upload video button is available");
-});
+      assert.ok(
+        exists(".discourse-video-upload"),
+        "the upload video button is available"
+      );
+    });
 
-test("it shows upload button when user is staff", async (assert) => {
-  updateCurrentUser({ staff: true });
+    test("it does not show upload button when can_upload_video is false", async (assert) => {
+      updateCurrentUser({ can_upload_video: false });
 
-  await visit("/");
-  await click("#create-topic");
+      await visit("/");
+      await click("#create-topic");
 
-  assert.ok(exists(".discourse-video-upload"), "the upload video button is available");
-});
-
-test("it does not show upload button when user does not have specified trust level", async (assert) => {
-  updateCurrentUser({ staff: false, trust_level: 0 });
-
-  await visit("/");
-  await click("#create-topic");
-
-  assert.ok(exists(".discourse-video-upload"), "the upload video button is available");
-});
+      assert.ok(
+        !exists(".discourse-video-upload"),
+        "the upload video button is not available"
+      );
+    });
+  }
+);


### PR DESCRIPTION
@oblakeerickson The test failure was due to [this](https://github.com/discourse/discourse-video/pull/16) commit, As we removed the condition check from the frontend and added it to the serializer, and tests were written on the basis of old code.