### PR TITLE
DEV: Handle array of files or single file for uploadHandler

### DIFF
--- a/assets/javascripts/discourse/initializers/discourse-video.js.es6
+++ b/assets/javascripts/discourse/initializers/discourse-video.js.es6
@@ -125,7 +125,14 @@ function initializeDiscourseVideo(api) {
 
     api.addComposerUploadHandler(
       siteSettings.discourse_video_file_extensions.split("|"),
-      (file) => {
+      (files) => {
+        let file;
+        if (Array.isArray(files)) {
+          file = files[0];
+        } else {
+          file = files;
+        }
+
         Ember.run.next(() => {
           showModal("discourse-video-upload-modal").setProperties({
             file,


### PR DESCRIPTION
In core, we are changing the uploadHandler API to send through
multiple files at a time instead of just one. This commit allows
for either a single file or array until the core change is done.
We are selecting the first file in the array because that is how
it used to work with jQuery file uploader, which sent through one
file at a time, with the modal opening just one of the sent through
files.