### PR TITLE
FIX: Avoid conflict with other plugins

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -57,19 +57,8 @@ after_initialize do
       end
     end
 
-    PostCustomField.transaction do
-      PostCustomField.where(post_id: post.id, name: DiscourseVideo::POST_CUSTOM_FIELD_NAME).delete_all
-      if video_ids.size > 0
-        params = video_ids.map do |val|
-          {
-            post_id: post.id,
-            name: DiscourseVideo::POST_CUSTOM_FIELD_NAME,
-            value: val
-          }
-        end
-        PostCustomField.create!(params)
-      end
-    end
+    post.custom_fields[DiscourseVideo::POST_CUSTOM_FIELD_NAME] = video_ids
+    post.save_custom_fields
 
     post.publish_change_to_clients! :discourse_video_video_changed
   end


### PR DESCRIPTION
Some other plugins (e.g. discourse-policy) call `save_custom_fields`
during the post cooking process. That was causing the discourse-video
changes to be overwritten. To fix this, we can switch to the standard
pattern.

See:

https://github.com/discourse/discourse-brightcove/commit/3ba54d0632ed0ac1f61b05bcd66a359e2b1de3f9