### PR TITLE
DEV: Move away from post_custom_fields

### DIFF
--- a/app/models/discourse_video/video.rb
+++ b/app/models/discourse_video/video.rb
@@ -12,20 +12,20 @@ module DiscourseVideo
     validates :state, inclusion: { in: %w(pending ready errored waiting),
                                    message: "%{value} is not a valid state" }
 
-    def post_custom_fields
-      PostCustomField.where(name: DiscourseVideo::POST_CUSTOM_FIELD_NAME).where("value LIKE ?", "#{self.video_id}%")
+    def video_posts
+      DiscourseVideo::VideoPost.where("video_info LIKE ?", "#{self.video_id}%")
     end
 
-    def post_custom_field_value
+    def video_info
       "#{video_id}:#{state}"
     end
 
-    def update_post_custom_fields!
-      post_custom_fields.update_all(value: post_custom_field_value)
+    def update_video_post_fields!
+      video_posts.update_all(video_info: video_info)
     end
 
     def publish_change_to_clients!
-      Post.find(post_custom_fields.pluck(:post_id)).each do |post|
+      Post.find(video_posts.pluck(:post_id)).each do |post|
         post.publish_change_to_clients! :discourse_video_video_changed
       end
     end

--- a/app/models/discourse_video/video_post.rb
+++ b/app/models/discourse_video/video_post.rb
@@ -1,6 +1,7 @@
+# frozen_string_literal: true
+
 module DiscourseVideo
   class VideoPost < ActiveRecord::Base
     belongs_to :post
   end
 end
-

--- a/app/models/discourse_video/video_post.rb
+++ b/app/models/discourse_video/video_post.rb
@@ -1,0 +1,6 @@
+module DiscourseVideo
+  class VideoPost < ActiveRecord::Base
+    belongs_to :post
+  end
+end
+

--- a/assets/javascripts/discourse/initializers/discourse-video.js.es6
+++ b/assets/javascripts/discourse/initializers/discourse-video.js.es6
@@ -73,7 +73,6 @@ function initializeDiscourseVideo(api) {
       }
 
       post.discourse_video.forEach((video_string) => {
-
         if (video_string) {
           const status = video_string.replace(`${videoId}:`, "");
           if (status === "ready") {

--- a/assets/javascripts/discourse/initializers/discourse-video.js.es6
+++ b/assets/javascripts/discourse/initializers/discourse-video.js.es6
@@ -67,29 +67,28 @@ function initializeDiscourseVideo(api) {
   function renderVideos($elem, post) {
     $("div[data-video-id]", $elem).each((index, container) => {
       const $container = $(container);
-      const video_id = $container.data("video-id").toString();
-      if (!post.discourse_video_videos) {
+      const videoId = $container.data("video-id").toString();
+      if (!post.discourse_video || !videoId) {
         return;
       }
 
-      const video_string = post.discourse_video_videos.find((v) => {
-        return v.indexOf(`${video_id}:`) === 0;
-      });
+      post.discourse_video.forEach((video_string) => {
 
-      if (video_string) {
-        const status = video_string.replace(`${video_id}:`, "");
-        if (status === "ready") {
-          renderVideo($container, video_id);
-        } else if (status === "errored") {
-          renderPlaceholder($container, "errored");
-        } else if (status === "waiting") {
-          renderPlaceholder($container, "waiting");
+        if (video_string) {
+          const status = video_string.replace(`${videoId}:`, "");
+          if (status === "ready") {
+            renderVideo($container, videoId);
+          } else if (status === "errored") {
+            renderPlaceholder($container, "errored");
+          } else if (status === "waiting") {
+            renderPlaceholder($container, "waiting");
+          } else {
+            renderPlaceholder($container, "pending");
+          }
         } else {
-          renderPlaceholder($container, "pending");
+          renderPlaceholder($container, "waiting");
         }
-      } else {
-        renderPlaceholder($container, "waiting");
-      }
+      });
     });
   }
 

--- a/db/migrate/20220128213022_create_discourse_video_video_posts.rb
+++ b/db/migrate/20220128213022_create_discourse_video_video_posts.rb
@@ -11,4 +11,3 @@ class CreateDiscourseVideoVideoPosts < ActiveRecord::Migration[6.1]
     end
   end
 end
-

--- a/db/migrate/20220128213022_create_discourse_video_video_posts.rb
+++ b/db/migrate/20220128213022_create_discourse_video_video_posts.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class CreateDiscourseVideoVideoPosts < ActiveRecord::Migration[6.1]
+  def change
+    create_table :discourse_video_video_posts do |t|
+      t.integer :post_id, null: false
+      t.string :video_info, null: false
+
+      t.datetime :created_at
+      t.datetime :updated_at
+    end
+  end
+end
+

--- a/db/migrate/20220131210333_copy_custom_fields_to_video_posts_table.rb
+++ b/db/migrate/20220131210333_copy_custom_fields_to_video_posts_table.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class CopyCustomFieldsToVideoPostsTable < ActiveRecord::Migration[6.1]
+  def up
+    PostCustomField.where(name: 'discourse_video').find_each do |pcf|
+      DiscourseVideo::VideoPost.create(post_id: pcf.post_id, video_info: pcf.value)
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/migrate/20220131210333_copy_custom_fields_to_video_posts_table.rb
+++ b/db/migrate/20220131210333_copy_custom_fields_to_video_posts_table.rb
@@ -2,9 +2,13 @@
 
 class CopyCustomFieldsToVideoPostsTable < ActiveRecord::Migration[6.1]
   def up
-    PostCustomField.where(name: 'discourse_video').find_each do |pcf|
-      DiscourseVideo::VideoPost.create(post_id: pcf.post_id, video_info: pcf.value)
-    end
+    execute <<~SQL
+      INSERT INTO discourse_video_video_posts (post_id, video_info, created_at, updated_at)
+      SELECT pcf.post_id, pcf.value, pcf.created_at, pcf.updated_at
+      FROM post_custom_fields pcf
+      WHERE pcf.name = 'discourse_video'
+      ON CONFLICT DO NOTHING
+    SQL
   end
 
   def down

--- a/plugin.rb
+++ b/plugin.rb
@@ -28,10 +28,14 @@ end
 after_initialize do
   require_relative "app/controllers/discourse_video/display_controller.rb"
 
-  register_post_custom_field_type('discourse_video', :string)
+  reloadable_patch do |plugin|
+    class ::Post
+      has_many :discourse_video, class_name: 'DiscourseVideo::VideoPost'
+    end
+  end
 
-  topic_view_post_custom_fields_allowlister do |user|
-    DiscourseVideo::POST_CUSTOM_FIELD_NAME
+  TopicView.on_preload do |topic_view|
+    topic_view.instance_variable_set(:@posts, topic_view.posts.includes(:discourse_video))
   end
 
   add_to_class(:guardian, :can_upload_video?) do
@@ -40,8 +44,8 @@ after_initialize do
     @user.trust_level >= SiteSetting.discourse_video_min_trust_level
   end
 
-  add_to_serializer(:post, :discourse_video_videos, false) do
-    Array(post_custom_fields[DiscourseVideo::POST_CUSTOM_FIELD_NAME])
+  add_to_serializer(:post, :discourse_video, false) do
+    Array(DiscourseVideo::VideoPost.where(post_id: object.id).pluck(:video_info))
   end
 
   add_to_serializer(:current_user, :can_upload_video) do
@@ -53,12 +57,20 @@ after_initialize do
 
     doc.css("div/@data-video-id").each do |media|
       if video = DiscourseVideo::Video.find_by_video_id(media.value)
-        video_ids << video.post_custom_field_value
+        video_ids << video.video_info
       end
     end
 
-    post.custom_fields[DiscourseVideo::POST_CUSTOM_FIELD_NAME] = video_ids
-    post.save_custom_fields
+    DiscourseVideo::VideoPost.where(post_id: post.id).delete_all
+    if video_ids.size > 0
+      params = video_ids.map do |val|
+        {
+          post_id: post.id,
+          video_info: val
+        }
+      end
+      DiscourseVideo::VideoPost.create!(params)
+    end
 
     post.publish_change_to_clients! :discourse_video_video_changed
   end


### PR DESCRIPTION
This commit switches away from using `post_custom_fields` and instead
uses a new `discourse_video_video_posts` table.

This move is necessary because the `post_custom_fields` were being
overwritten by another plugin (discourse-translate) causing this plugin
to not work properly.