### PR TITLE
DEV: Fix another post custom fields reference

### DIFF
--- a/app/controllers/discourse_video/upload_controller.rb
+++ b/app/controllers/discourse_video/upload_controller.rb
@@ -68,7 +68,7 @@ module DiscourseVideo
           video.playback_id = data["data"]["playback_ids"][0]["id"]
           video.state = DiscourseVideo::Video::READY
           video.save!
-          video.update_post_custom_fields!
+          video.update_video_post_fields!
           video.publish_change_to_clients!
         end
       end


### PR DESCRIPTION
`update_post_custom_fields!` was renamed to `update_video_post_fields!`

Follow up to: 723959a83f959a73b00ae2bfa684b6e1c7f9fb24