### PR TITLE
FEATURE: Add support for downloading mp4 version

### DIFF
--- a/app/controllers/discourse_video/display_controller.rb
+++ b/app/controllers/discourse_video/display_controller.rb
@@ -2,14 +2,14 @@
 
 module DiscourseVideo
   class DisplayController < ::ApplicationController
-    skip_before_action :check_xhr
     requires_plugin DiscourseVideo
 
     def get_playback_id
       video_id = params.require(:video_id)
-      playback_id = DiscourseVideo::Video.where(video_id: video_id).pluck(:playback_id).first
+      video_info = DiscourseVideo::Video.where(video_id: video_id).as_json(only: [:playback_id, :mp4_filename]).first
 
-      render json: { playback_id: playback_id }
+      render json: video_info
     end
+
   end
 end

--- a/app/controllers/discourse_video/upload_controller.rb
+++ b/app/controllers/discourse_video/upload_controller.rb
@@ -19,7 +19,7 @@ module DiscourseVideo
 
       hijack do
         begin
-          result = MuxApi.create_direct_upload_2
+          result = MuxApi.create_direct_upload
           video = DiscourseVideo::Video.new(
             video_id: result["data"]["id"],
             state: result["data"]["status"],

--- a/assets/javascripts/discourse/components/discourse-video-upload-form.js.es6
+++ b/assets/javascripts/discourse/components/discourse-video-upload-form.js.es6
@@ -90,9 +90,9 @@ export default Ember.Component.extend({
   uploadComplete() {
     const videoInfo = this.get("videoInfo");
     this.setProgress("complete", { info: `[video=${videoInfo["video_id"]}]` });
-    let videoTag = `[video=${videoInfo["video_id"]}]`
+    let videoTag = `[video=${videoInfo["video_id"]}]`;
     if (this.siteSettings.discourse_video_enable_mp4_download === true) {
-      videoTag += ` [download-video=${videoInfo["video_id"]}]`
+      videoTag += ` [download-video=${videoInfo["video_id"]}]`;
     }
     this.appEvents.trigger(
       "composer:insert-text",

--- a/assets/javascripts/discourse/components/discourse-video-upload-form.js.es6
+++ b/assets/javascripts/discourse/components/discourse-video-upload-form.js.es6
@@ -90,9 +90,13 @@ export default Ember.Component.extend({
   uploadComplete() {
     const videoInfo = this.get("videoInfo");
     this.setProgress("complete", { info: `[video=${videoInfo["video_id"]}]` });
+    let videoTag = `[video=${videoInfo["video_id"]}]`
+    if (this.siteSettings.discourse_video_enable_mp4_download === true) {
+      videoTag += ` [download-video=${videoInfo["video_id"]}]`
+    }
     this.appEvents.trigger(
       "composer:insert-text",
-      `[video=${videoInfo["video_id"]}]`
+      videoTag
     );
     this.sendAction("closeModal");
   },

--- a/assets/javascripts/discourse/components/discourse-video-upload-form.js.es6
+++ b/assets/javascripts/discourse/components/discourse-video-upload-form.js.es6
@@ -94,10 +94,7 @@ export default Ember.Component.extend({
     if (this.siteSettings.discourse_video_enable_mp4_download === true) {
       videoTag += ` [download-video=${videoInfo["video_id"]}]`;
     }
-    this.appEvents.trigger(
-      "composer:insert-text",
-      videoTag
-    );
+    this.appEvents.trigger("composer:insert-text", videoTag);
     this.sendAction("closeModal");
   },
 

--- a/assets/javascripts/discourse/initializers/discourse-video.js.es6
+++ b/assets/javascripts/discourse/initializers/discourse-video.js.es6
@@ -44,7 +44,7 @@ function initializeDiscourseVideo(api) {
         downloadLink.className = "download-mux-video";
         downloadLink.appendChild(text);
         const mp4Url = `https://stream.mux.com/${data.playback_id}/high.mp4`;
-        downloadLink.href = mp4Url
+        downloadLink.href = mp4Url;
         videoContainer[0].appendChild(downloadLink);
       });
     });

--- a/assets/javascripts/discourse/initializers/discourse-video.js.es6
+++ b/assets/javascripts/discourse/initializers/discourse-video.js.es6
@@ -43,7 +43,7 @@ function initializeDiscourseVideo(api) {
         let text = document.createTextNode("Download video");
         downloadLink.className = "download-mux-video";
         downloadLink.appendChild(text);
-        const mp4Url = `https://stream.mux.com/${data.playback_id}/high.mp4`;
+        const mp4Url = `https://stream.mux.com/${data.playback_id}/high.mp4?download=${data.playback_id}.mp4`;
         downloadLink.href = mp4Url;
         videoContainer[0].appendChild(downloadLink);
       });

--- a/assets/javascripts/lib/discourse-markdown/discourse-video.js.es6
+++ b/assets/javascripts/lib/discourse-markdown/discourse-video.js.es6
@@ -11,6 +11,19 @@ function addVideo(buffer, matches, state) {
   buffer.push(token);
 }
 
+function addDownloadVideo(buffer, matches, state) {
+  const video_id = matches[1];
+
+  let token = new state.Token("div_open", "div", 1);
+  token.attrs = [
+    ["class", "discourse-download-video-container"],
+    ["data-download-video-id", video_id],
+  ];
+  buffer.push(token);
+  token = new state.Token("div_close", "div", -1);
+  buffer.push(token);
+}
+
 export function setup(helper) {
   helper.allowList(["div.discourse-video-container", "div[data-video-id]"]);
 
@@ -21,5 +34,16 @@ export function setup(helper) {
     };
 
     md.core.textPostProcess.ruler.push("discourse-video", rule);
+  });
+
+  helper.allowList(["div.discourse-download-video-container", "div[data-download-video-id]"]);
+
+  helper.registerPlugin((md) => {
+    const rule = {
+      matcher: /\[download-video=([a-zA-Z0-9]+)\]/,
+      onMatch: addDownloadVideo,
+    };
+
+    md.core.textPostProcess.ruler.push("discourse-download-video", rule);
   });
 }

--- a/assets/javascripts/lib/discourse-markdown/discourse-video.js.es6
+++ b/assets/javascripts/lib/discourse-markdown/discourse-video.js.es6
@@ -36,7 +36,10 @@ export function setup(helper) {
     md.core.textPostProcess.ruler.push("discourse-video", rule);
   });
 
-  helper.allowList(["div.discourse-download-video-container", "div[data-download-video-id]"]);
+  helper.allowList([
+    "div.discourse-download-video-container",
+    "div[data-download-video-id]",
+  ]);
 
   helper.registerPlugin((md) => {
     const rule = {

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4,6 +4,7 @@ en:
       modal_title: "Upload Video"
       modal_subtitle: "Select a video to upload and embed"
       select_file: "Select File"
+      download_video: "Download Video"
       file: "File"
       upload_toolbar_title: Upload Video
       upload_progress:

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -7,6 +7,8 @@ en:
     discourse_video_min_trust_level: Minimum required trust level for uploading videos
     discourse_video_file_extensions: A list of file extensions which can be uploaded
     discourse_video_uploads_per_day_per_user: Maximum number of videos that a user can upload per day
+    discourse_video_enable_mp4_storage: "Turns on mp4 storage of videos going forward"
+    discourse_video_enable_mp4_download: "Allows users to download videos"
   discourse_video:
     post:
       errors:

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -7,7 +7,6 @@ en:
     discourse_video_min_trust_level: Minimum required trust level for uploading videos
     discourse_video_file_extensions: A list of file extensions which can be uploaded
     discourse_video_uploads_per_day_per_user: Maximum number of videos that a user can upload per day
-    discourse_video_enable_mp4_storage: "Turns on mp4 storage of videos going forward"
     discourse_video_enable_mp4_download: "Allows users to download videos"
   discourse_video:
     post:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -21,9 +21,6 @@ plugins:
     list_type: compact
   discourse_video_uploads_per_day_per_user:
     default: 10
-  discourse_video_enable_mp4_storage:
-    default: false
-    client: true
   discourse_video_enable_mp4_download:
     default: false
     client: true

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -21,3 +21,9 @@ plugins:
     list_type: compact
   discourse_video_uploads_per_day_per_user:
     default: 10
+  discourse_video_enable_mp4_storage:
+    default: false
+    client: true
+  discourse_video_enable_mp4_download:
+    default: false
+    client: true

--- a/lib/discourse_video/mux_api.rb
+++ b/lib/discourse_video/mux_api.rb
@@ -8,7 +8,7 @@ module DiscourseVideo
     def self.create_direct_upload
       token_id = SiteSetting.discourse_video_mux_token_id
       token_secret = SiteSetting.discourse_video_mux_token_secret
-      mp4_storage = SiteSetting.discourse_video_enable_mp4_storage
+      mp4_storage = SiteSetting.discourse_video_enable_mp4_download
       mp4_support = (mp4_storage == true) ? "standard" : "none"
       url = "https://api.mux.com/video/v1/uploads"
       auth = Base64.strict_encode64("#{token_id}:#{token_secret}")

--- a/lib/discourse_video/mux_api.rb
+++ b/lib/discourse_video/mux_api.rb
@@ -5,14 +5,17 @@ require 'base64'
 module DiscourseVideo
   class MuxApi
 
-    def self.create_direct_upload_2
+    def self.create_direct_upload
       token_id = SiteSetting.discourse_video_mux_token_id
       token_secret = SiteSetting.discourse_video_mux_token_secret
+      mp4_storage = SiteSetting.discourse_video_enable_mp4_storage
+      mp4_support = (mp4_storage == true) ? "standard" : "none"
       url = "https://api.mux.com/video/v1/uploads"
       auth = Base64.strict_encode64("#{token_id}:#{token_secret}")
       body = {
         new_asset_settings: {
           playback_policy: ["public"],
+          mp4_support: mp4_support
         },
         cors_origin: "*",
       }

--- a/spec/lib/discourse_video/mux_api_spec.rb
+++ b/spec/lib/discourse_video/mux_api_spec.rb
@@ -13,7 +13,7 @@ describe DiscourseVideo::MuxApi do
   describe "creating video with mp4 support" do
 
     before do
-      SiteSetting.discourse_video_enable_mp4_storage = true
+      SiteSetting.discourse_video_enable_mp4_download = true
     end
 
     body = {
@@ -44,7 +44,7 @@ describe DiscourseVideo::MuxApi do
 
   describe "creating video without mp4 support" do
     before do
-      SiteSetting.discourse_video_enable_mp4_storage = false
+      SiteSetting.discourse_video_enable_mp4_download = false
     end
 
     body = {

--- a/spec/lib/discourse_video/mux_api_spec.rb
+++ b/spec/lib/discourse_video/mux_api_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+describe DiscourseVideo::MuxApi do
+
+  let(:url) { "https://api.mux.com/video/v1/uploads" }
+
+  before do
+    SiteSetting.discourse_video_mux_token_id = "987654321"
+    SiteSetting.discourse_video_mux_token_secret = "abc"
+  end
+
+  describe "creating video with mp4 support" do
+
+    before do
+      SiteSetting.discourse_video_enable_mp4_storage = true
+    end
+
+    body = {
+      new_asset_settings: {
+        playback_policy: ["public"],
+        mp4_support: "standard"
+      },
+      cors_origin: "*",
+    }
+
+    let!(:creation_stub) do
+      stub_request(:post, url).
+        with(
+           body: body.to_json,
+           headers: {
+             'Authorization' => 'Basic OTg3NjU0MzIxOmFiYw==',
+             'Content-Type' => 'application/json',
+             'Host' => 'api.mux.com'
+           }).
+        to_return(status: 200, body: {}.to_json, headers: {})
+    end
+
+    it "creates with mp4 support" do
+      api = described_class.create_direct_upload
+      expect(creation_stub).to have_been_requested.once
+    end
+  end
+
+  describe "creating video without mp4 support" do
+    before do
+      SiteSetting.discourse_video_enable_mp4_storage = false
+    end
+
+    body = {
+      new_asset_settings: {
+        playback_policy: ["public"],
+        mp4_support: "none"
+      },
+      cors_origin: "*",
+    }
+
+    let!(:creation_stub) do
+      stub_request(:post, url).
+        with(
+           body: body.to_json,
+           headers: {
+             'Authorization' => 'Basic OTg3NjU0MzIxOmFiYw==',
+             'Content-Type' => 'application/json',
+             'Host' => 'api.mux.com'
+           }).
+        to_return(status: 200, body: {}.to_json, headers: {})
+    end
+
+    it "creates without mp4 support" do
+      api = described_class.create_direct_upload
+      expect(creation_stub).to have_been_requested.once
+    end
+  end
+
+end

--- a/spec/requests/upload_controller_spec.rb
+++ b/spec/requests/upload_controller_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require_relative '../fabricators/video_fabricator.rb'
 
 def mux_signature(data)
   timestamp = 1234


### PR DESCRIPTION
By default when uploading a video to mux regardless of format it is converted
to a streaming .m3u8 file. This change allows for mux to also store a
mp4 version of the upload file in addition to the streaming file. This
allows us to link directly to the mp4 video for downloading, but still
allow for streaming for optimal video playback.

This change includes two new site settings, one for enabling mp4
storage, and another one that adds a link to download the mp4 file below
the video player.