### PR TITLE
FIX: Link to the correct mp4 filename

### DIFF
--- a/app/controllers/discourse_video/upload_controller.rb
+++ b/app/controllers/discourse_video/upload_controller.rb
@@ -73,6 +73,28 @@ module DiscourseVideo
         end
       end
 
+      if data["type"] == "video.asset.static_renditions.ready"
+        upload_id = data["data"]["upload_id"]
+        video = DiscourseVideo::Video.find_by_video_id(upload_id)
+        filenames = []
+
+        if video
+          files = data["data"]["static_renditions"]["files"]
+          files.each do |f|
+            filenames << f["name"]
+          end
+
+          if filenames.include?("high.mp4")
+            video.mp4_filename = "high.mp4"
+          else
+            video.mp4_filename = "low.mp4"
+          end
+
+          video.save!
+        end
+
+      end
+
       render json: success_json
 
     end

--- a/assets/javascripts/discourse/initializers/discourse-video.js.es6
+++ b/assets/javascripts/discourse/initializers/discourse-video.js.es6
@@ -50,9 +50,11 @@ function initializeDiscourseVideo(api) {
         );
         downloadLink.className = "download-mux-video";
         downloadLink.appendChild(text);
-        const mp4Url = `https://stream.mux.com/${data.playback_id}/high.mp4?download=${data.playback_id}.mp4`;
+        const mp4Url = `https://stream.mux.com/${data.playback_id}/${data.mp4_filename}?download=${data.playback_id}.mp4`;
         downloadLink.href = mp4Url;
-        videoContainer.appendChild(downloadLink);
+        if (data.mp4_filename) {
+          videoContainer.appendChild(downloadLink);
+        }
       });
     });
   }

--- a/db/migrate/20220510163938_add_mp4_filename_to_discourse_video_video.rb
+++ b/db/migrate/20220510163938_add_mp4_filename_to_discourse_video_video.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddMp4FilenameToDiscourseVideoVideo < ActiveRecord::Migration[7.0]
+  def change
+    add_column :discourse_video_videos, :mp4_filename, :string
+  end
+end

--- a/spec/requests/upload_controller_spec.rb
+++ b/spec/requests/upload_controller_spec.rb
@@ -17,6 +17,19 @@ describe DiscourseVideo::UploadController do
   let(:asset_created_data) { "{\"type\":\"video.upload.asset_created\",\"request_id\":null,\"object\":{\"type\":\"upload\",\"id\":\"HPL7WRiJV01jaMUC02PBLO8VLM3zigAqWYC3bhju8wd7s\"},\"id\":\"fe518ca9-6845-4685-9f3b-d44d62462c14\",\"environment\":{\"name\":\"Development\",\"id\":\"km8j7v\"},\"data\":{\"timeout\":3600,\"test\":true,\"status\":\"asset_created\",\"new_asset_settings\":{\"playback_policies\":[\"public\"]},\"id\":\"HPL7WRiJV01jaMUC02PBLO8VLM3zigAqWYC3bhju8wd7s\",\"cors_origin\":\"*\",\"asset_id\":\"MYPDwHNwvPG11AtxzY9Oz01MP4XPs01r83OGBIfnholuk\"},\"created_at\":\"2021-06-10T04:02:13.000000Z\",\"attempts\":[],\"accessor_source\":null,\"accessor\":null}" }
   let(:ready_data) { "{\"type\":\"video.asset.ready\",\"request_id\":null,\"object\":{\"type\":\"asset\",\"id\":\"MYPDwHNwvPG11AtxzY9Oz01MP4XPs01r83OGBIfnholuk\"},\"id\":\"a71c5a45-0212-4b61-bac0-4e1821900bf3\",\"environment\":{\"name\":\"Development\",\"id\":\"km8j7v\"},\"data\":{\"upload_id\":\"HPL7WRiJV01jaMUC02PBLO8VLM3zigAqWYC3bhju8wd7s\",\"tracks\":[{\"type\":\"video\",\"max_width\":1280,\"max_height\":704,\"max_frame_rate\":59.649,\"id\":\"JziaHVw1vsRx986Typs8biCBA9NiA9dhCQpGuDCQ3fQ\",\"duration\":8.494833}],\"test\":true,\"status\":\"ready\",\"playback_ids\":[{\"policy\":\"public\",\"id\":\"cmXKFx1M6y5LmC00Nr02v3UFC2bCyTM4aGu43Yd4ZEFpU\"}],\"mp4_support\":\"none\",\"max_stored_resolution\":\"HD\",\"max_stored_frame_rate\":59.649,\"master_access\":\"none\",\"id\":\"MYPDwHNwvPG11AtxzY9Oz01MP4XPs01r83OGBIfnholuk\",\"duration\":8.583333,\"created_at\":1623297733,\"aspect_ratio\":\"20:11\"},\"created_at\":\"2021-06-10T04:02:15.000000Z\",\"attempts\":[],\"accessor_source\":null,\"accessor\":null}" }
 
+  let(:static_renditions_data) { {
+    type: "video.asset.static_renditions.ready",
+    data: {
+      upload_id: video.video_id,
+      static_renditions: {
+        status: "ready",
+        files: [
+          name: "low.mp4"
+        ]
+      }
+    }
+  }.to_json }
+
   before do
     SiteSetting.discourse_video_enabled = true
     SiteSetting.discourse_video_mux_webhook_signing_secret = "test"
@@ -46,6 +59,16 @@ describe DiscourseVideo::UploadController do
         post "/discourse_video/webhook", params: JSON.parse(ready_data), as: :json, headers: { "Content-Type" => "aplication/json", "Mux-Signature" => mux_signature(ready_data) }
         video.reload
       end.to change { video.state }.from(DiscourseVideo::Video::PENDING).to(DiscourseVideo::Video::READY)
+    end
+
+    it 'accepts static_renditions.ready requests' do
+      expect do
+        post "/discourse_video/webhook",
+          params: JSON.parse(static_renditions_data),
+          as: :json,
+          headers: { "Content-Type" => "aplication/json", "Mux-Signature" => mux_signature(static_renditions_data) }
+        video.reload
+      end.to change { video.mp4_filename }.from(nil).to("low.mp4")
     end
   end
 end


### PR DESCRIPTION
Depending on the original source video quality mux will return one or
several different filenames for stored `.mp4` videos.

See:

https://docs.mux.com/guides/video/enable-static-mp4-renditions#creating-the-mp4-streaming-url

This change:

- adds a migration for storing the mp4 filename
- adds a webhook to update the filename once mux has processed it
- hides the download link if mux hasn't called our webhook yet

Follow up to: dc65e44758139212d91e3932cef682569c6de1ce
