### PR TITLE
DEV: Pass respect_plugin_enabled to add_to_serializer as keyword argument

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -41,7 +41,7 @@ after_initialize do
     @user.trust_level >= SiteSetting.discourse_video_min_trust_level
   end
 
-  add_to_serializer(:post, :discourse_video, false) do
+  add_to_serializer(:post, :discourse_video, respect_plugin_enabled: false) do
     Array(DiscourseVideo::VideoPost.where(post_id: object.id).pluck(:video_info))
   end
 


### PR DESCRIPTION
### What is this change?

Passing the `respect_plugin_enabled` argument to `#add_to_serializer` as a positional argument is deprecated. It is now expected to be a keyword argument. This PR adds the keyword.