### PR TITLE
FIX: post can be undefined

### DIFF
--- a/assets/javascripts/discourse/initializers/discourse-video.js
+++ b/assets/javascripts/discourse/initializers/discourse-video.js
@@ -119,9 +119,13 @@ function initializeDiscourseVideo(api) {
   }
 
   function renderVideos(elem, post) {
+    if (!post?.discourse_video) {
+      return;
+    }
+
     elem.querySelectorAll("div[data-video-id]").forEach(function (container) {
       const videoId = container.getAttribute("data-video-id").toString();
-      if (!post?.discourse_video || !videoId) {
+      if (!videoId) {
         return;
       }
 
@@ -149,7 +153,7 @@ function initializeDiscourseVideo(api) {
         const videoId = container
           .getAttribute("data-download-video-id")
           .toString();
-        if (!post.discourse_video || !videoId) {
+        if (!videoId) {
           return;
         }
 


### PR DESCRIPTION
Followup to https://github.com/discourse/discourse-video/commit/38ccc4beeab23fa5dd83a447b029856bb20328a7 as there are two places with this behavior.

This commit moves the check at the top.