### PR TITLE
FIX: Composer placeholder previews

### DIFF
--- a/assets/javascripts/discourse/initializers/discourse-video.js
+++ b/assets/javascripts/discourse/initializers/discourse-video.js
@@ -170,18 +170,19 @@ function initializeDiscourseVideo(api) {
 
   api.decorateCookedElement(
     (elem, helper) => {
-      if (helper) {
-        const post = helper.getModel();
-        renderVideos(elem, post);
-      } else {
-        elem
-          .querySelectorAll("div[data-video-id]")
-          .forEach(function (container) {
-            container.innerHTML = `<p><div class="onebox-placeholder-container">
-            <span class="placeholder-icon video"></span>
-          </div></p>`;
-          });
+      const post = helper && typeof helper.getModel === "function" && helper.getModel();
+      if (!post) {
+        elem.querySelectorAll("div[data-video-id]").forEach((container) => {
+          container.innerHTML = `
+            <p>
+              <div class="onebox-placeholder-container">
+                <span class="placeholder-icon video"></span>
+              </div>
+            </p>`;
+        });
+        return;
       }
+      renderVideos(elem, post);
     },
     { id: "discourse-video" }
   );

--- a/assets/javascripts/discourse/initializers/discourse-video.js
+++ b/assets/javascripts/discourse/initializers/discourse-video.js
@@ -170,7 +170,8 @@ function initializeDiscourseVideo(api) {
 
   api.decorateCookedElement(
     (elem, helper) => {
-      const post = helper && typeof helper.getModel === "function" && helper.getModel();
+      const post =
+        helper && typeof helper.getModel === "function" && helper.getModel();
       if (!post) {
         elem.querySelectorAll("div[data-video-id]").forEach((container) => {
           container.innerHTML = `


### PR DESCRIPTION
Apparently since this commit in core:

https://github.com/discourse/discourse/commit/54b1e3195c7cbc3df223f2dd932a830e888eb33c

previews in the composer have stopped working. This change gets it
working again.

Before:

![CleanShot 2025-04-10 at 19 12 21@2x](https://github.com/user-attachments/assets/309511a0-ed0e-467c-a719-6a4b0dd2cd53)

After:

![CleanShot 2025-04-10 at 19 12 55@2x](https://github.com/user-attachments/assets/41e98ffb-dde0-49a9-b8a0-362ac7edd65b)

