### PR TITLE
FIX: Max video duration based on trust level

### DIFF
--- a/assets/javascripts/discourse/components/modal/discourse-video-upload-form.gjs
+++ b/assets/javascripts/discourse/components/modal/discourse-video-upload-form.gjs
@@ -37,8 +37,7 @@ export default class DiscourseVideoUploadForm extends Component {
     }
 
     return (
-      this.videoDurationMinutes < this.maxVideoDurationMinutes &&
-      this.currentUser.trust_level === 4
+      this.videoDurationMinutes < this.maxVideoDurationMinutes
     );
   }
 

--- a/assets/javascripts/discourse/components/modal/discourse-video-upload-form.gjs
+++ b/assets/javascripts/discourse/components/modal/discourse-video-upload-form.gjs
@@ -36,9 +36,7 @@ export default class DiscourseVideoUploadForm extends Component {
       return true;
     }
 
-    return (
-      this.videoDurationMinutes < this.maxVideoDurationMinutes
-    );
+    return this.videoDurationMinutes < this.maxVideoDurationMinutes;
   }
 
   get maxVideoDurationMinutes() {


### PR DESCRIPTION
The logic for max video duration based on trust level was wrong and not
working for users less than trust level 4. This was a regression caused
by a refactoring in 54718f50d783491fa1ae3683064556effd5ec6e2.

This fix allows users with a trust level < 4 to upload videos as long as
they don't exceed the duration set by
`SiteSetting.discourse_video_max_duration_minutes`.
